### PR TITLE
Remove extraneous space

### DIFF
--- a/examples/01_introduction/02_Functions.md
+++ b/examples/01_introduction/02_Functions.md
@@ -9,7 +9,7 @@ fun printMessage(message: String): Unit {                               // 1
     println(message)
 }
 
-fun printMessageWithPrefix(message: String, prefix : String = "Info") { // 2
+fun printMessageWithPrefix(message: String, prefix: String = "Info") { // 2
     println("[$prefix] $message")
 }
 


### PR DESCRIPTION
Unless I'm missing something, there shouldn't be a space between the argument name and type in a function declaration. Obnoxiously small edit, I know.