### PR TITLE
added a docker/jekyll shutdown script

### DIFF
--- a/shutdown.sh
+++ b/shutdown.sh
@@ -4,7 +4,6 @@
 # 2. search for docker container ID and kill it. 
 # Latter is default/uncommented.  
 
-feel free to use/comment pref
 TO_STOP="jekyll"
 
 # SOLUTION 1: search for jekyll process and kill. 

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -10,7 +10,7 @@ TO_STOP="jekyll"
 # ps aux | grep ${TO_STOP} | awk '{print $2}' | xargs kill -9 2>/dev/null
 # END SOLUTION  1
 
-# METHOD 2: search for the container ID and kill it. 
+# SOLUTION 2: search for the container ID and kill it. 
 CONTAINER=$( docker container ls  | grep $TO_STOP | cut -d" " -f1 )
 CLENGTH=${#CONTAINER}
 STATUS="successfully"

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -1,20 +1,28 @@
+# With this script you can stop jekyll instance and kill its docker container.
+# I propose 2 solutions:
+# 1. just send a -9 kill signal to the "root" PID, and related/child processes will go down silently  
+# 2. search for docker container ID and kill it. 
+# Latter is default/uncommented.  
+
+feel free to use/comment pref
 TO_STOP="jekyll"
 
-# METHOD 1: search for jekyll process and kill. 
+# SOLUTION 1: search for jekyll process and kill. 
 # ps aux | grep ${TO_STOP} | awk '{print $2}' | xargs kill -9 2>/dev/null
-# END METHOD 1
+# END SOLUTION  1
 
 # METHOD 2: search for the container ID and kill it. 
 CONTAINER=$( docker container ls  | grep $TO_STOP | cut -d" " -f1 )
 CLENGTH=${#CONTAINER}
 STATUS="successfully"
 
-if [[ $CLENGTH -gt 0 ]];then 
+if [[ $CLENGTH -gt 0 ]];then
+# you can stop instead of kill. Please refer to: https://docs.docker.com/engine/reference/commandline/docker/
 	docker container kill $CONTAINER 1>/dev/null
 else
 	STATUS="already"
 fi
-# END METHOD 2
+# END SOLUTION  2
 
 # RESULT: get a log string 
 # NOTE: exit status 123 is related to method one, when grep search for ruby and other bin stuff 

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -1,0 +1,26 @@
+TO_STOP="jekyll"
+
+# METHOD 1: search for jekyll process and kill. 
+# ps aux | grep ${TO_STOP} | awk '{print $2}' | xargs kill -9 2>/dev/null
+# END METHOD 1
+
+# METHOD 2: search for the container ID and kill it. 
+CONTAINER=$( docker container ls  | grep $TO_STOP | cut -d" " -f1 )
+CLENGTH=${#CONTAINER}
+STATUS="successfully"
+
+if [[ $CLENGTH -gt 0 ]];then 
+	docker container kill $CONTAINER 1>/dev/null
+else
+	STATUS="already"
+fi
+# END METHOD 2
+
+# RESULT: get a log string 
+# NOTE: exit status 123 is related to method one, when grep search for ruby and other bin stuff 
+if [[ $? -eq 123 || $? -eq 0 ]];then 
+        echo "${TO_STOP} ${STATUS} stopped...";
+else
+	echo "Error: something went wrong!"	
+fi
+


### PR DESCRIPTION
run shutdown.sh to automate the jekyll & its container shutdown, instead of closing jekyll manually (w/ ^C), and searching for container ID to stop/kill it.

Tested on:
```bash
$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
$ docker -v
Docker version 18.09.0, build 4d60db4
```

Cheers