### PR TITLE
Fix typo in examples/01_introduction/05_Classes

### DIFF
--- a/examples/01_introduction/05_Classes.md
+++ b/examples/01_introduction/05_Classes.md
@@ -25,7 +25,7 @@ fun main() {
 </div>  
 
 1. Declares a class named `Customer` without any properties or user-defined constructors. A non-parameterized default constructor is created by Kotlin automatically.
-2. Declares a class with two propetries: immutable `id` and mutable `email`, and a constructor with two parameters `id` and `email`.
+2. Declares a class with two properties: immutable `id` and mutable `email`, and a constructor with two parameters `id` and `email`.
 3. Creates an instance of the class `Customer` via the default constructor. Note that there is no `new` keyword in Kotlin.
 4. Creates an instance of the class `Contact` using the constructor with two arguments.
 5. Accesses the property `id`.


### PR DESCRIPTION
'properties' is misspelled as 'propetries'