### PR TITLE
Fix missing space typo in 04_Smart Casts

### DIFF
--- a/examples/06_productivity_boosters/04_Smart Casts.md
+++ b/examples/06_productivity_boosters/04_Smart Casts.md
@@ -41,7 +41,7 @@ fun main() {
 1. Declares a nullable variable.
 2. Smart-cast to non-nullable (thus allowing direct access to `isLeapYear`).
 3. Smart-cast inside a condition (this is possible because, like Java, Kotlin uses [short-circuiting](https://en.wikipedia.org/wiki/Short-circuit_evaluation)).
-4. Smart-cast inside acondition (also enabled by short-circuiting).
+4. Smart-cast inside a condition (also enabled by short-circuiting).
 5. Smart-cast to the subtype `LocalDate`.
 
 This way, you can automatically use variables as desired in most cases without doing obvious casts manually.


### PR DESCRIPTION
added missing space to 'acondition' resulting in 'a condition'