### PR TITLE
fix typo in let.md

### DIFF
--- a/examples/06_scope_functions/01_let.md
+++ b/examples/06_scope_functions/01_let.md
@@ -12,7 +12,7 @@ fun customPrint(s: String) {
 
 fun main() {
 //sampleStart
-    val empty = "testKotlin".let {         // 1
+    val empty = "test".let {         // 1
         customPrint(it)                    // 2
         it.isEmpty()                       // 3
     }

--- a/examples/06_scope_functions/01_let.md
+++ b/examples/06_scope_functions/01_let.md
@@ -12,7 +12,7 @@ fun customPrint(s: String) {
 
 fun main() {
 //sampleStart
-    val empty = "test".let {         // 1
+    val empty = "test".let {               // 1
         customPrint(it)                    // 2
         it.isEmpty()                       // 3
     }


### PR DESCRIPTION
Because the 1, 2 explanations refer to this string as "test".